### PR TITLE
Defect: Circle or Rectangle on the map is getting draw without fill color

### DIFF
--- a/addon/utils/tools.js
+++ b/addon/utils/tools.js
@@ -44,7 +44,8 @@ export default {
     ],
     style: {
       strokeColor: '#374046',
-      fillColor: '#374046'
+      fillColor: '#374046',
+      fillOpacity: 0.5
     },
     fillColorTransparent: true,
   },
@@ -72,7 +73,8 @@ export default {
     ],
     style: {
       strokeColor: '#374046',
-      fillColor: '#374046'
+      fillColor: '#374046',
+      fillOpacity: 0.5
     },
     fillColorTransparent: true,
   },
@@ -87,7 +89,8 @@ export default {
     ],
     style: {
       strokeColor: '#374046',
-      fillColor: '#374046'
+      fillColor: '#374046',
+      fillOpacity: 0.5
     },
     fillColorTransparent: true,
   }


### PR DESCRIPTION
- Select draw mode.
- Change markup tool to Polygon.
- Uncheck the fill color option checkbox.
- Draw a Polygon on the map
- Change markup tool to Rectangle or Circle
- Draw a Circle or Rectangle on the map while fill color option checkbox is checked

Issue- Circle or Rectangle on the map is getting draw without fill color while fill color checkbox was checked.